### PR TITLE
make listening adress configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,8 @@ statsd_exporter_version: '0.20.2'
 statsd_exporter_arch: linux-amd64
 statsd_exporter_metrics_path: metrics
 statsd_exporter_user: statsd_exporter
+statsd_exporter_listen_tcp_adress: "127.0.0.1:8125"
+statsd_exporter_listen_udp_adress: "127.0.0.1:8125"
 statsd_exporter_config: ""
 # mappings:
 # - match: ([\w-]+)\.gunicorn\.request\.status\.(\d+)

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User={{ statsd_exporter_user }}
 Group={{ statsd_exporter_user }}
-ExecStart=/usr/local/bin/statsd_exporter --web.listen-address='{{ statsd_exporter_host_address }}:{{ statsd_exporter_host_port }}' --statsd.listen-tcp="{{ statsd_listen_tcp_adress }}" --statsd.listen-udp="{{ statsd_listen_udp_adress }}" --statsd.mapping-config='{{ statsd_exporter_config_dir }}/statsd.conf'
+ExecStart=/usr/local/bin/statsd_exporter --web.listen-address='{{ statsd_exporter_host_address }}:{{ statsd_exporter_host_port }}' --statsd.listen-tcp="{{ statsd_exporter_listen_tcp_adress }}" --statsd.listen-udp="{{ statsd_exporter_listen_udp_adress }}" --statsd.mapping-config='{{ statsd_exporter_config_dir }}/statsd.conf'
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true
 Restart=on-failure

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User={{ statsd_exporter_user }}
 Group={{ statsd_exporter_user }}
-ExecStart=/usr/local/bin/statsd_exporter --web.listen-address='{{ statsd_exporter_host_address }}:{{ statsd_exporter_host_port }}' --statsd.listen-tcp="127.0.0.1:8125" --statsd.listen-udp="127.0.0.1:8125" --statsd.mapping-config='{{ statsd_exporter_config_dir }}/statsd.conf'
+ExecStart=/usr/local/bin/statsd_exporter --web.listen-address='{{ statsd_exporter_host_address }}:{{ statsd_exporter_host_port }}' --statsd.listen-tcp="{{ statsd_listen_tcp_adress }}" --statsd.listen-udp="{{ statsd_listen_udp_adress }}" --statsd.mapping-config='{{ statsd_exporter_config_dir }}/statsd.conf'
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true
 Restart=on-failure


### PR DESCRIPTION
The listening adresses were hardcoded in the template. This PR makes them configurable by implementing two new variables.